### PR TITLE
Death upon more than 3 living neighbors

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -8,7 +8,8 @@ class Game
 
   def nextRound
     @grid.cells.each do |cell|
-      cell.die if cell.livingNeighbors.count < 2
+      cell.die if cell.livingNeighbors.count < 2 ||
+                  cell.livingNeighbors.count > 3
     end
 
     @round = round + 1

--- a/spec/game_of_life_spec.rb
+++ b/spec/game_of_life_spec.rb
@@ -228,5 +228,23 @@ RSpec.describe("Game of Life") do
 
       expect(cell.alive?).to be(false)
     end
+
+    it("kills off a cell with 6 living neighbors") do
+      grid = Grid.new
+      game = Game.new(grid)
+      cell = Cell.new(grid, 1, 1)
+      Cell.new(grid, 0, 0).die
+      Cell.new(grid, 1, 0).die
+      Cell.new(grid, 2, 0)
+      Cell.new(grid, 0, 1)
+      Cell.new(grid, 2, 1)
+      Cell.new(grid, 0, 2)
+      Cell.new(grid, 1, 2)
+      Cell.new(grid, 2, 2)
+
+      game.nextRound
+
+      expect(cell.alive?).to be(false)
+    end
   end
 end

--- a/spec/game_of_life_spec.rb
+++ b/spec/game_of_life_spec.rb
@@ -264,5 +264,23 @@ RSpec.describe("Game of Life") do
 
       expect(cell.alive?).to be(false)
     end
+
+    it("kills off a cell with 8 living neighbors") do
+      grid = Grid.new
+      game = Game.new(grid)
+      cell = Cell.new(grid, 1, 1)
+      Cell.new(grid, 0, 0)
+      Cell.new(grid, 1, 0)
+      Cell.new(grid, 2, 0)
+      Cell.new(grid, 0, 1)
+      Cell.new(grid, 2, 1)
+      Cell.new(grid, 0, 2)
+      Cell.new(grid, 1, 2)
+      Cell.new(grid, 2, 2)
+
+      game.nextRound
+
+      expect(cell.alive?).to be(false)
+    end
   end
 end

--- a/spec/game_of_life_spec.rb
+++ b/spec/game_of_life_spec.rb
@@ -246,5 +246,23 @@ RSpec.describe("Game of Life") do
 
       expect(cell.alive?).to be(false)
     end
+
+    it("kills off a cell with 7 living neighbors") do
+      grid = Grid.new
+      game = Game.new(grid)
+      cell = Cell.new(grid, 1, 1)
+      Cell.new(grid, 0, 0).die
+      Cell.new(grid, 1, 0)
+      Cell.new(grid, 2, 0)
+      Cell.new(grid, 0, 1)
+      Cell.new(grid, 2, 1)
+      Cell.new(grid, 0, 2)
+      Cell.new(grid, 1, 2)
+      Cell.new(grid, 2, 2)
+
+      game.nextRound
+
+      expect(cell.alive?).to be(false)
+    end
   end
 end

--- a/spec/game_of_life_spec.rb
+++ b/spec/game_of_life_spec.rb
@@ -192,5 +192,23 @@ RSpec.describe("Game of Life") do
 
       expect(cell.alive?)
     end
+
+    it("kills off a cell with 4 living neighbors") do
+      grid = Grid.new
+      game = Game.new(grid)
+      cell = Cell.new(grid, 1, 1)
+      Cell.new(grid, 0, 0).die
+      Cell.new(grid, 1, 0).die
+      Cell.new(grid, 2, 0).die
+      Cell.new(grid, 0, 1).die
+      Cell.new(grid, 2, 1)
+      Cell.new(grid, 0, 2)
+      Cell.new(grid, 1, 2)
+      Cell.new(grid, 2, 2)
+
+      game.nextRound
+
+      expect(cell.alive?).to be(false)
+    end
   end
 end

--- a/spec/game_of_life_spec.rb
+++ b/spec/game_of_life_spec.rb
@@ -210,5 +210,23 @@ RSpec.describe("Game of Life") do
 
       expect(cell.alive?).to be(false)
     end
+
+    it("kills off a cell with 5 living neighbors") do
+      grid = Grid.new
+      game = Game.new(grid)
+      cell = Cell.new(grid, 1, 1)
+      Cell.new(grid, 0, 0).die
+      Cell.new(grid, 1, 0).die
+      Cell.new(grid, 2, 0).die
+      Cell.new(grid, 0, 1)
+      Cell.new(grid, 2, 1)
+      Cell.new(grid, 0, 2)
+      Cell.new(grid, 1, 2)
+      Cell.new(grid, 2, 2)
+
+      game.nextRound
+
+      expect(cell.alive?).to be(false)
+    end
   end
 end


### PR DESCRIPTION
Kill of a cell if it has more than 3 living neighbors.
Cell death is due to over-crowding and thus a shortage of resources.
